### PR TITLE
Fixed 'D4' was not declared in this scope error

### DIFF
--- a/blink_LED_program_IotWS/blink_LED_program_IotWS.ino
+++ b/blink_LED_program_IotWS/blink_LED_program_IotWS.ino
@@ -4,14 +4,14 @@
 
 //the setup function runs once when you press reset or power the board
 void setup() {
-  pinMode(D4, OUTPUT);
+  pinMode(2, OUTPUT);
 }
 
 // the loop function runs over and over again forever
 void loop() {
-  digitalWrite(D4, HIGH);   // turn the LED on (HIGH is the voltage level)
+  digitalWrite(2, HIGH);   // turn the LED on (HIGH is the voltage level)
   delay(1000);                       // wait for a second
-  digitalWrite(D4, LOW);    // turn the LED off by making the voltage LOW
+  digitalWrite(2, LOW);    // turn the LED off by making the voltage LOW
   delay(1000);                       // wait for a second
 }
 


### PR DESCRIPTION
The ESP8266 GPIO pins do not line up with development board pin names. The number corresponding to pin D4 is 2.