### PR TITLE
Fixed "D0' was not declared in this scope

### DIFF
--- a/IR_sensor_interface/IR_sensor_interface.ino
+++ b/IR_sensor_interface/IR_sensor_interface.ino
@@ -6,13 +6,13 @@
 int state;
 void setup() {
   // put your setup code here, to run once:
-    pinMode(D0, INPUT);   // Making D0 as digital input
+    pinMode(16, INPUT);   // Making D0 as digital input
     Serial.begin(9600);   // Serial Monitor baud rate
 }
 
 void loop() {
   // put your main code here, to run repeatedly:
- state = digitalRead(D0);  //Reading Digital input
+ state = digitalRead(16);  //Reading Digital input
  if (state == LOW){        //Condition accoring to input state     
   Serial.println("Move");
   }else {


### PR DESCRIPTION
The ESP8266 GPIO pins do not always line up with development board pin names. The number corresponding to pin D0 is 16.